### PR TITLE
Patent Defense: Clarify license "for the software"

### DIFF
--- a/polyform.md
+++ b/polyform.md
@@ -50,7 +50,7 @@ These terms do not allow you to sublicense or transfer any licenses granted unde
 
 ## Patent Defense
 
-If you or your company makes any written claim alleging that the software infringes or contributes to infringement of a patent, your patent license granted under these terms ends immediately.
+If you or your company makes any written claim alleging that the software infringes or contributes to infringement of a patent, your patent license for the software granted under these terms ends immediately.
 
 ## No Liability
 


### PR DESCRIPTION
Thin tiny patch clarifies that Patent Defense terminates only the patent for the software against which the claim was brought, by paralleling  the language of Excuse.