### PR TITLE
Add Personal Uses

### DIFF
--- a/polyform.md
+++ b/polyform.md
@@ -26,13 +26,15 @@ The licensor grants you a patent license for the software that covers patent cla
 
 Any noncommercial purpose is a permitted purpose.
 
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, without any anticipated commercial application, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance is for a permitted purpose.
+
 ## Noncommercial Organizations
 
 Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is a permitted purpose, even if that use involves occasional arguably commercial uses.
 
 _Note to Reviewers:  We are particularly interested in feedback from noncommercial organizations on whether this "safe harbor" is sufficient for whitelisting Polyformlicensed software by policy._
-
-_Note to Reviewers:  We are also interested in feedback about whether we should also include a "safe harbor" for personal uses._
 
 ## Fair Use
 

--- a/polyform.md
+++ b/polyform.md
@@ -28,7 +28,7 @@ Any noncommercial purpose is a permitted purpose.
 
 ## Personal Uses
 
-Personal use for research, experiment, and testing for the benefit of public knowledge, without any anticipated commercial application, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance is for a permitted purpose.
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is for a permitted purpose.
 
 ## Noncommercial Organizations
 


### PR DESCRIPTION
This PR adds a new section, analogous to Noncommercial Organizations, to create a "safe harbor" for listed personal uses. The idea is to help sharpen the lines of "noncommercial purpose" and increase licensee confidence.

For those who may have seen earlier, nonpublic drafts, this language has been condensed from its original list form, like Noncommercial Organizations.