### PR TITLE
Explain variants in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,25 @@ source text for [Polyform Project](https://polyformproject.org) licenses
 The Polyform Project is a group of experienced licensing lawyers and technologists developing simple, standardized, plain-language software source code licenses.  Polyform aims to fill gaps in the menu of standardized software licenses, like non-commercial, trial, and small-business-only terms.
 
 Have a look at [`polyform.md`](./polyform.md) for the latest license language.
+
+## Variants
+
+Much as [Creative Commons](https://creativecommons.org) offers a [suite of licenses](https://creativecommons.org/licenses/#licenses), Polyform will offer a number of variants.
+
+Polyform's base license will be a limited, noncommercial license.  Variants will add sections to that base license:
+
+| Variant          | [Changes] | [Distrib.] | [Trial] | [Internal] | [SMB] |
+| ---------------- | --------- | ---------- | ------- | ---------- | ----- |
+| `Polyform`       |           |            |         |            |       |
+| `Polyform-CL-DL` | Yes       | Yes        |         |            |       |
+| `Polyform-CL`    | Yes       |            |         |            |       |
+| `Polyform-DL`    |           | Yes        |         |            |       |
+| `Polyform-FT`    |           |            | Yes     |            |       |
+| `Polyform-IB`    |           |            |         | Yes        |       |
+| `Polyform-SB`    |           |            |         |            | Yes   |
+
+[Distrib.]: ./polyform.md#dl-distribution-license
+[Changes]: ./polyform.md#cl-changes-and-new-works-license
+[Trial]: ./polyform.md#ft-free-trial
+[Internal]: ./polyform.md#ib-internal-business-use
+[SMB]: ./polyform.md#sb-small-business


### PR DESCRIPTION
This PR adds a new section to `README` explaining the concepts of a suite of licenses, a base license, and variants adding new sections to the base license. I've also included a table of variants we currently anticipate publishing.

I expect we'll add at least one new optional section, and therefore at least one variant. We may also drop optional sections, to keep scope tight and the number of variants manageable.