### PR TITLE
Require preservation of supplied notice lines (close #36)

### DIFF
--- a/generate-variants
+++ b/generate-variants
@@ -62,7 +62,7 @@ Object.keys(variants).forEach(function (suffix) {
 function writeVariant (stream, suffix, options) {
   var skipContent = false
   // Pipe through fmt -60 -u.
-  var fmt = childProcess.spawn('fmt', ['-60', '-u'])
+  var fmt = childProcess.spawn('fmt', ['-65', '-u'])
   fmt.stdout.pipe(stream)
   var input = fmt.stdin
   contentLines.forEach(function (line) {

--- a/generate-variants
+++ b/generate-variants
@@ -60,16 +60,12 @@ Object.keys(variants).forEach(function (suffix) {
 })
 
 function writeVariant (stream, suffix, options) {
-  var skipNext = false
+  var skipContent = false
   // Pipe through fmt -60 -u.
   var fmt = childProcess.spawn('fmt', ['-60', '-u'])
   fmt.stdout.pipe(stream)
   var input = fmt.stdin
   contentLines.forEach(function (line) {
-    if (skipNext) {
-      skipNext = false
-      return
-    }
     if (line.startsWith('# ')) {
       input.write(
         '# Polyform ' + suffix + ' License ' + version
@@ -86,6 +82,7 @@ function writeVariant (stream, suffix, options) {
         )
       }
     } else if (line.startsWith('## ')) {
+      skipContent = false
       // If the <h2> has a two-letter code...
       var match = /^## ([A-Z]{2}): (.+)$/.exec(line)
       if (match) {
@@ -97,7 +94,7 @@ function writeVariant (stream, suffix, options) {
         // ... otherwise skip both the heading and th
         // text that follows.
         } else {
-          skipNext = true
+          skipContent = true
         }
       // If the heading does not have a two-letter code,
       // write it out.
@@ -105,7 +102,7 @@ function writeVariant (stream, suffix, options) {
         input.write('\n\n' + line)
       }
     } else {
-      input.write('\n\n' + line)
+      if (!skipContent) input.write('\n\n' + line)
     }
   })
   input.end('\n')

--- a/polyform.md
+++ b/polyform.md
@@ -14,7 +14,9 @@ The licensor grants you a copyright license for the software, to do everything y
 
 ## DL: Distribution License
 
-The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software, such as:
+The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software, such as:
 
 > Required Notice: Copyright Example, Inc. (http://example.com)
 

--- a/polyform.md
+++ b/polyform.md
@@ -20,10 +20,6 @@ You must ensure that anyone who gets a copy of any part of the software from you
 
 > Required Notice: Copyright Example, Inc. (http://example.com)
 
-On POSIX systems, you can find these lines with a command like:
-
-`find . -type f -exec grep "^[[:space:]]*Required Notice:" {} +`
-
 ## CL: Changes and New Works License
 
 The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.

--- a/polyform.md
+++ b/polyform.md
@@ -14,7 +14,7 @@ The licensor grants you a copyright license for the software, to do everything y
 
 ## DL: Distribution License
 
-The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for its text above, as well the text of any notice lines beginning with `Required Licensing Information:` that the licensor provided with the software, such as:
+The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for its text above, as well the text of any text lines beginning with `Required Licensing Information:` that the licensor provided with the software, such as:
 
 > Required Licensing Information: Copyright Example, Inc. (http://example.com)
 

--- a/polyform.md
+++ b/polyform.md
@@ -14,9 +14,9 @@ The licensor grants you a copyright license for the software, to do everything y
 
 ## DL: Distribution License
 
-The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Licensing Information:` that the licensor provided with the software, such as:
+The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software, such as:
 
-> Required Licensing Information: Copyright Example, Inc. (http://example.com)
+> Required Notice: Copyright Example, Inc. (http://example.com)
 
 ## CL: Changes and New Works License
 

--- a/polyform.md
+++ b/polyform.md
@@ -18,6 +18,12 @@ The licensor grants you an additional copyright license to distribute copies of 
 
 > Required Notice: Copyright Example, Inc. (http://example.com)
 
+On POSIX systems, you can find these lines with a command like:
+
+```sh
+find . -type f -exec grep "^[[:space:]]*Required Notice:" {} +
+```
+
 ## CL: Changes and New Works License
 
 The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.

--- a/polyform.md
+++ b/polyform.md
@@ -14,9 +14,7 @@ The licensor grants you a copyright license for the software, to do everything y
 
 ## DL: Distribution License
 
-The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.
-
-You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for its text above.
+The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for its text above, as well the text of any notice lines beginning with `Required Notice:` that the licensor provided with the software.
 
 ## CL: Changes and New Works License
 

--- a/polyform.md
+++ b/polyform.md
@@ -14,7 +14,7 @@ The licensor grants you a copyright license for the software, to do everything y
 
 ## DL: Distribution License
 
-The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for its text above, as well the text of any notice lines beginning with `Required Notice:` that the licensor provided with the software.
+The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for its text above, as well the text of any notice lines beginning with `Required Licensing Information:` that the licensor provided with the software.
 
 ## CL: Changes and New Works License
 

--- a/polyform.md
+++ b/polyform.md
@@ -14,7 +14,7 @@ The licensor grants you a copyright license for the software, to do everything y
 
 ## DL: Distribution License
 
-The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for their text above, as well the text of any text lines beginning with `Required Licensing Information:` that the licensor provided with the software, such as:
+The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Licensing Information:` that the licensor provided with the software, such as:
 
 > Required Licensing Information: Copyright Example, Inc. (http://example.com)
 

--- a/polyform.md
+++ b/polyform.md
@@ -14,7 +14,7 @@ The licensor grants you a copyright license for the software, to do everything y
 
 ## DL: Distribution License
 
-The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for its text above, as well the text of any text lines beginning with `Required Licensing Information:` that the licensor provided with the software, such as:
+The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for their text above, as well the text of any text lines beginning with `Required Licensing Information:` that the licensor provided with the software, such as:
 
 > Required Licensing Information: Copyright Example, Inc. (http://example.com)
 

--- a/polyform.md
+++ b/polyform.md
@@ -14,7 +14,9 @@ The licensor grants you a copyright license for the software, to do everything y
 
 ## DL: Distribution License
 
-The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for its text above, as well the text of any notice lines beginning with `Required Licensing Information:` that the licensor provided with the software.
+The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.  You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for its text above, as well the text of any notice lines beginning with `Required Licensing Information:` that the licensor provided with the software, such as:
+
+> Required Licensing Information: Copyright Example, Inc. (http://example.com)
 
 ## CL: Changes and New Works License
 

--- a/polyform.md
+++ b/polyform.md
@@ -20,9 +20,7 @@ The licensor grants you an additional copyright license to distribute copies of 
 
 On POSIX systems, you can find these lines with a command like:
 
-```sh
-find . -type f -exec grep "^[[:space:]]*Required Notice:" {} +
-```
+`find . -type f -exec grep "^[[:space:]]*Required Notice:" {} +`
 
 ## CL: Changes and New Works License
 


### PR DESCRIPTION
This PR adds text to the notice-preservation requirement of Distribution License requiring preservation of notice license identified by a specific string prefix.  I have a few things in mind:

1. Avoid turning the license text into a form with blanks, like MIT and BSD, that licensors have to "fill out". Remain a fixed license text, like GPL, Apache-2.0, or the Creative Commons licenses.

2. Give licensors the flexibility to include whatever information they like, such as identification, websites, contact methods, and notices that other licenses are available, if any.

3.  Simplify compliance by providing a single, machine-identifiable marker to test whether there are other notices to preserve, and identify them for preservation. (e.g. `grep -r -F "Required Notice:"`)

Which "magic string" to choose for the notice marker could turn into a bikeshed real quick.  I'm not wedded to `Required Notice:`, but I think anything we choose should be unambiguous, short, and generic enough for other licenses to use if they choose. I would point out, however, that as yet I have _not_ thought of this as a means of assuring the licensor "credit". That would require additional terms to make sure end users, including service users, receive the notices, and that they be at least discoverable, if not prominent. If we do proper "credit" terms, we should probably do them in 2.0.0, later.

## Prior Art

### CC-BY-SA-4.0
> a. Attribution.
> 1\. If You Share the Licensed Material (including in modified form), You must:
> A. retain the following if it is supplied by the Licensor with the Licensed Material:
> i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
> ii. a copyright notice;
> iii. a notice that refers to this Public License;
> iv. a notice that refers to the disclaimer of warranties;
> v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
> ...
> 2\. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
> 3\. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.

### Apache-2.0

> 4\. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
> ...
> c. You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
> d. If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 