### PR TITLE
Distribution License: Require URL from top of license

### DIFF
--- a/generate-variants
+++ b/generate-variants
@@ -71,8 +71,19 @@ function writeVariant (stream, suffix, options) {
     }
     if (line.startsWith('# ')) {
       input.write(
-        '# Polyform ' + suffix + ' License\n\n' + version
+        '# Polyform ' + suffix + ' License ' + version
       )
+    } else if (line.includes('{License URL}')) {
+      input.write('\n\n')
+      if (version.toLowerCase().includes('draft')) {
+        input.write('https://github.com/polyformproject/polyform-licenses/')
+      } else {
+        input.write(
+          'https://polyformproject.org/licenses/' +
+          suffix.toLowerCase() +
+          '/' + version.trim()
+        )
+      }
     } else if (line.startsWith('## ')) {
       // If the <h2> has a two-letter code...
       var match = /^## ([A-Z]{2}): (.+)$/.exec(line)

--- a/polyform.md
+++ b/polyform.md
@@ -1,5 +1,7 @@
 # Polyform Project License Language
 
+{License URL}
+
 _Note to Reviewers:  The Polyform Project will publish a suite of licenses, akin to Creative Commons' BY, BY-SA, NC, NC-SA, and so on. The sections below with two-letter codes in their headings, like PC and CL, will appear only in corresponding licenses and will not be marked with two-letter codes. The "base" noncommercial license will not include any of the sections with two-letter codes_ 
 
 ## Acceptance
@@ -12,7 +14,7 @@ The licensor grants you a copyright license for the software, to do everything y
 
 ## DL: Distribution License
 
-The licensor grants you an additional copyright license to distribute copies of the software, and if these terms grant you an additional license to make changes and new works, to distribute your changes and new works, as well.  You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or a link to their text on <https://polyformproject.org>.
+The licensor grants you an additional copyright license to distribute copies of the software, and if these terms grant you an additional license to make changes and new works, to distribute your changes and new works, as well.  You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for its text above.
 
 ## CL: Changes and New Works License
 


### PR DESCRIPTION
This PR prints URLs for the different license texts at their tops, below their titles, and changes Distribution License to allow use of that URL, rather than a full copy of the text.

All credit to @lindenksv, whose [comment](https://github.com/polyformproject/polyform-licenses/pull/37#issuecomment-504573577) on #37 pointed out that licensees are very likely to just copy any URL they see in the license, rather than browse to polyformproject.org and find the right page for the particular variant that applies to the software.