### PR TITLE
Patent Defense: Address workers and companies (close #3)

### DIFF
--- a/polyform.md
+++ b/polyform.md
@@ -62,7 +62,7 @@ These terms do not allow you to sublicense or transfer any licenses granted unde
 
 ## Patent Defense
 
-If you make any written claim that the software infringes or contributes to infringement of a patent, your patent license for the software granted under these terms ends immediately.  If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately.  If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
 
 ## No Liability
 

--- a/polyform.md
+++ b/polyform.md
@@ -62,7 +62,7 @@ These terms do not allow you to sublicense or transfer any licenses granted unde
 
 ## Patent Defense
 
-If you make any written claim alleging that the software infringes or contributes to infringement of a patent, your patent license for the software granted under these terms ends immediately.  If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+If you make any written claim that the software infringes or contributes to infringement of a patent, your patent license for the software granted under these terms ends immediately.  If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
 
 ## No Liability
 

--- a/polyform.md
+++ b/polyform.md
@@ -62,7 +62,7 @@ These terms do not allow you to sublicense or transfer any licenses granted unde
 
 ## Patent Defense
 
-If you or your company makes any written claim alleging that the software infringes or contributes to infringement of a patent, your patent license for the software granted under these terms ends immediately.
+If you make any written claim alleging that the software infringes or contributes to infringement of a patent, your patent license for the software granted under these terms ends immediately.  If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
 
 ## No Liability
 


### PR DESCRIPTION
This PR splits Patent Defense in two. The first sentence terminates the patent license completely when the licensee themself makes a patent claim. The second sentence terminates the patent license _only for work for a company_ when that company makes a patent claim.

If LicensorCo releases software under Polyform, Bob uses that software at work for LicenseeCo, and LicenseeCo makes a patent claim against LicensorCo, Bob's patent license for the software now ends for work for LicenseeCo, but Bob remains licensed for other uses of the software, like personal uses or work for other companies.