### PR TITLE
Distribution License: Don't cover internal-use work (close #38)

### DIFF
--- a/polyform.md
+++ b/polyform.md
@@ -14,7 +14,7 @@ The licensor grants you a copyright license for the software, to do everything y
 
 ## DL: Distribution License
 
-The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works, as well.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.
+The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.
 
 You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for its text above.
 

--- a/polyform.md
+++ b/polyform.md
@@ -14,7 +14,9 @@ The licensor grants you a copyright license for the software, to do everything y
 
 ## DL: Distribution License
 
-The licensor grants you an additional copyright license to distribute copies of the software, and if these terms grant you an additional license to make changes and new works, to distribute your changes and new works, as well.  You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for its text above.
+The licensor grants you an additional copyright license to distribute copies of the software.  If these terms grant you an additional license to make changes and new works, your license to distribute covers distributing your changes and new works, as well.  However, if these terms allow you to make changes and new works for internal business operations, your license to distribute does not cover distributing those changes and new works.
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets the text of these terms or the URL for its text above.
 
 ## CL: Changes and New Works License
 


### PR DESCRIPTION
This PR changes the terms so that when Distribution License, Changes and New Work License, and Internal Business Use all appear in a variant, Distribution License does _not_ allow distribution of changes and new work made for internal use.

@heathermeeker this is really a question about the specification for `Polyform-Internal`. Should it permit distributing internal-use changes or not?