### PR TITLE
Use "terms" instead of "rules" throughout

### DIFF
--- a/polyform.md
+++ b/polyform.md
@@ -6,7 +6,7 @@ _Note to Reviewers:  The Polyform Project will publish a suite of licenses, akin
 
 ## Acceptance
 
-In order to get any license under these terms, you must agree to their rules.  Those rules are both obligations under your agreement and conditions to all the licenses granted to you under these terms.  The licensor may not end that agreement, or revoke any licenses granted under it, except per [Violations](#violations) and [Patent Defense](#patent-defence).
+In order to get any license under these terms, you must agree to them.  These terms are both obligations under your agreement and conditions to all the licenses granted to you.  The licensor may not end that agreement, or revoke any licenses granted under it, except per [Violations](#violations) and [Patent Defense](#patent-defence).
 
 ## Copyright License
 
@@ -72,7 +72,7 @@ If you or your company makes any written claim alleging that the software infrin
 
 ## Violations
 
-If you are notified in writing that you have broken any rule of these terms, you can keep the licenses granted to you under these terms by coming fully into compliance with these terms within 29 days of receiving the notice.  If you do not stop violating these terms within that time, your agreement under these terms ends immediately, and your licenses for the software end with it.  This excuse section is only available to you once.
+If you are notified in writing that you have broken any of these terms, you can keep the licenses granted to you under these terms by coming fully into compliance with these terms within 29 days of receiving the notice.  If you do not stop violating these terms within that time, your agreement under these terms ends immediately, and your licenses for the software end with it.  This excuse section is only available to you once.
 
 ## Definitions
 


### PR DESCRIPTION
This PR implements feedback from @lindenksv and @careed95073 via Google Doc.  Paraphrasing them there:  The use of "rules" is strange and offputting, potentially for both lawyer and non-lawyer readers.