### PR TITLE
Rewrite Noncompete in Plain Terms

### DIFF
--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -38,7 +38,7 @@ Any purpose is a permitted purpose, except for providing any good or service tha
 
 ## Competing Uses
 
-A good or service competes with the software if it provides so much of the software's functionality to users, and so little additional functionality of a different kind, that it becomes a practical substitute for the software for at least some potential users.  A good or service competes even if it offers the functionality of the software as a different kind of software: application as service, library as plugin, framework as development tool, interpreter as operating system, and so on.
+A good or service competes with the software if it provides so much of the software's functionality to users, and so little additional functionality of a different kind, that it becomes a practical substitute for the software for at least some potential users.  A good or service competes even if it offers the functionality of the software as a different kind of software: application as service, library as plugin, framework as development tool, interpreter as operating system, and so on, or for a different language or platform.
 
 ## Prior Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -38,7 +38,7 @@ Any purpose is a permitted purpose, except for providing any good or service tha
 
 ## Competing Uses
 
-A good or service competes with the software if it provides so much of the software's functionality to users, and so little additional functionality of a different kind, that it becomes a practical substitute for the software.  The good or service competes even if it offers the functionality of the software as a different kind of software: application as service, plugin as library, framework as development tool, interpreter as operating system, and so on.
+A good or service competes with the software if it provides so much of the software's functionality to users, and so little additional functionality of a different kind, that it becomes a practical substitute for the software for some or all potential users.  The good or service competes even if it offers the functionality of the software as a different kind of software: application as service, plugin as library, framework as development tool, interpreter as operating system, and so on.
 
 ## Prior Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -34,7 +34,7 @@ You may have "fair use" rights for the software under the law. These terms do no
 
 ## Noncompete
 
-Providing any offering that does not compete with the software is a permitted purpose.  An offering competes with the software if it functions as an economic substitute for the software, for at least some potential users, even if provided free of charge.
+Other than providing any offering that competes with the software, any purpose is a permitted purpose.  An offering competes with the software if it functions as an economic substitute for the software, for at least some potential users, even if provided free of charge.
 
 ## Prior Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -38,7 +38,7 @@ Any purpose is a permitted purpose, except for providing any good or service tha
 
 ## Competing Uses
 
-A good or service competes with the software if it provides so much of the software's functionality to users, and so little additional functionality of a different kind, that it becomes a practical substitute for the software for some or all potential users.  A good or service competes even if it offers the functionality of the software as a different kind of software: application as service, library as plugin, framework as development tool, interpreter as operating system, and so on.
+A good or service competes with the software if it provides so much of the software's functionality to users, and so little different functionality, that it becomes a practical substitute for the software for at least some potential users.  A good or service competes even if it offers the functionality of the software as a different kind of software: application as service, library as plugin, framework as development tool, interpreter as operating system, and so on.
 
 ## Prior Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -38,7 +38,7 @@ Any purpose is a permitted purpose, except for providing any good or service tha
 
 ## Competing Uses
 
-A good or service competes with the software if it provides so much of the software's functionality to users, and so little additional functionality of a different kind, that it becomes a practical substitute for the software for some or all potential users.  A good or service competes even if it offers the functionality of the software as a different kind of software: application as service, plugin as library, framework as development tool, interpreter as operating system, and so on.
+A good or service competes with the software if it provides so much of the software's functionality to users, and so little additional functionality of a different kind, that it becomes a practical substitute for the software for some or all potential users.  A good or service competes even if it offers the functionality of the software as a different kind of software: application as service, library as plugin, framework as development tool, interpreter as operating system, and so on.
 
 ## Prior Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -38,7 +38,7 @@ Any purpose is a permitted purpose, except for providing any good or service tha
 
 ## Competing Uses
 
-A good or service competes with the software if it provides so much of the software's functionality to users, and so little additional functionality of a different kind, that it becomes a practical substitute for the software for some or all potential users.  The good or service competes even if it offers the functionality of the software as a different kind of software: application as service, plugin as library, framework as development tool, interpreter as operating system, and so on.
+A good or service competes with the software if it provides so much of the software's functionality to users, and so little additional functionality of a different kind, that it becomes a practical substitute for the software for some or all potential users.  A good or service competes even if it offers the functionality of the software as a different kind of software: application as service, plugin as library, framework as development tool, interpreter as operating system, and so on.
 
 ## Prior Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -34,11 +34,11 @@ You may have "fair use" rights for the software under the law. These terms do no
 
 ## Noncompete
 
-Other than providing any offering that competes with the software, any purpose is a permitted purpose.  An offering competes with the software if it functions as an economic substitute for the software, for at least some potential users, even if provided free of charge.
+Any purpose is a permitted purpose, other than providing any good or service that competes with the software.  A good or service competes with the software if it functions as an economic substitute for the software, for at least some potential users, even if provided free of charge.
 
 ## Prior Uses
 
-If you are using the software to provide an offering that does not compete with the software, and the licensor releases a new version of the software under these terms that brings your offering into competition with the software, your permission to use prior versions of the software does not change.
+If you are using the software to provide a good or service that does not compete with the software, and the licensor releases a new version of the software under these terms that brings your good or service into competition with the software, your permission to use prior versions of the software does not change.
 
 ## No Other Rights
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -38,7 +38,7 @@ Any purpose is a permitted purpose, except for providing any good or service tha
 
 ## Competing Uses
 
-A good or service competes with the software if it provides so much of the software's functionality to users, and so little additional functionality of a different kind, that it becomes a practical substitute for the software for at least some potential users.  A good or service competes even if it offers the functionality of the software as a different kind of software: application as service, library as plugin, framework as development tool, interpreter as operating system, and so on, or for a different language or platform.
+A good or service competes with the software if it provides so much of the software's functionality to users, and so little additional functionality of a different kind, that it becomes a practical substitute for the software for at least some potential users.  A good or service competes even if it offers the functionality of the software as a different kind of software: application as service, library as plugin, framework as development tool, interpreter as operating system, and so on, or for a different language or platform.  If you market a good or service as a practical substitute for the software, it competes with the software under these terms.
 
 ## Prior Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -38,7 +38,7 @@ Any purpose is a permitted purpose, except for providing any good or service tha
 
 ## Competing Uses
 
-A good or service competes with the software if it provides so much of the software's functionality to users, and so little different functionality, that it becomes a practical substitute for the software for at least some potential users.  A good or service competes even if it offers the functionality of the software as a different kind of software: application as service, library as plugin, framework as development tool, interpreter as operating system, and so on.
+A good or service competes with the software if it provides so much of the software's functionality to users, and so little additional functionality of a different kind, that it becomes a practical substitute for the software for at least some potential users.  A good or service competes even if it offers the functionality of the software as a different kind of software: application as service, library as plugin, framework as development tool, interpreter as operating system, and so on.
 
 ## Prior Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -28,18 +28,6 @@ The licensor grants you an additional copyright license to make changes and new 
 
 The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
 
-## Noncommercial Purposes
-
-Any noncommercial purpose is a permitted purpose.
-
-## Personal Uses
-
-Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
-
-## Noncommercial Organizations
-
-Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
-
 ## Fair Use
 
 You may have "fair use" rights for the software under the law. These terms do not limit them.

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -46,7 +46,11 @@ You may have "fair use" rights for the software under the law. These terms do no
 
 ## Noncompete
 
-It is not a permitted purpose to provide any offering that competes with the software or any other offering the licensor provides using the software.  However, if you are using the software to provide an offering that does not compete, and the licensor begins providing a competing offering using the software, you may continue using versions of the software available under these terms at that time to provide your offering, but not any later versions made available under these terms.
+Providing any offering that does not compete with the software is a permitted purpose.  An offering competes with the software if it functions as an economic substitute for the software, for at least some potential users, even if provided free of charge.
+
+## Prior Uses
+
+If you are using the software to provide an offering that does not compete with the software, and the licensor releases a new version of the software under these terms that brings your offering into competition with the software, your permission to use prior versions of the software does not change.
 
 ## No Other Rights
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -34,7 +34,11 @@ You may have "fair use" rights for the software under the law. These terms do no
 
 ## Noncompete
 
-Any purpose is a permitted purpose, other than providing any good or service that competes with the software.  A good or service competes with the software if it functions as an economic substitute for the software, for at least some potential users, even if provided free of charge.
+Any purpose is a permitted purpose, except for providing any good or service that competes with the software.
+
+## Competing Uses
+
+A good or service competes with the software if it provides so much of the software's functionality to users, and so little additional functionality of a different kind, that it becomes a practical substitute for the software.  The good or service competes even if it offers the functionality of the software as a different kind of software: application as service, plugin as library, framework as development tool, interpreter as operating system, and so on.
 
 ## Prior Uses
 

--- a/README.md
+++ b/README.md
@@ -8,19 +8,21 @@ The Polyform Project is a group of experienced licensing lawyers and technologis
 
 Much as [Creative Commons](https://creativecommons.org) offers a [suite of licenses](https://creativecommons.org/licenses/#licenses), Polyform will offer a number of variations.
 
-| License                   | Use | Change | Distribute | Noncommercial | Trial | Internal | SMB |
-| ------------------------- | --- | ------ | ---------- | ------------- | ----- | -------- | --- |
-| [Polyform-Strict]         | Yes |        |            | Yes           |       |          |     |
-| [Polyform-Noncommercial]  | Yes | Yes    | Yes        | Yes           |       |          |     |
-| [Polyform-Free-Trial]     | Yes | Yes    |            |               | Yes   |          |     |
-| [Polyform-Internal-Use]   | Yes | Yes    |            |               |       | Yes      |     |
-| [Polyform-Small-Business] | Yes | Yes    | Yes        |               |       |          | Yes |
+| License                   | Use | Change | Distribute | Noncommercial | Trial | Internal | SMB | Noncompeting |
+| ------------------------- | --- | ------ | ---------- | ------------- | ----- | -------- | --- | ------------ |
+| [Polyform-Strict]         | Yes |        |            | Yes           |       |          |     |              |
+| [Polyform-Noncommercial]  | Yes | Yes    | Yes        | Yes           |       |          |     |              |
+| [Polyform-Free-Trial]     | Yes | Yes    |            |               | Yes   |          |     |              |
+| [Polyform-Internal-Use]   | Yes | Yes    |            |               |       | Yes      |     |              |
+| [Polyform-Small-Business] | Yes | Yes    | Yes        |               |       |          | Yes |              |
+| [Polyform-Noncompete]     | Yes | Yes    | Yes        |               |       |          |     | Yes          |
 
 [Polyform-Strict]: ./Polyform-Strict.md
 [Polyform-Noncommercial]: ./Polyform-Noncommercial.md
 [Polyform-Free-Trial]: ./Polyform-Free-Trial.md
 [Polyform-Internal-Use]: ./Polyform-Internal-Use.md
 [Polyform-Small-Business]: ./Polyform-Small-Business.md
+[Polyform-Noncompete]: ./Polyform-Small-Noncompete.md
 
 ## License
 


### PR DESCRIPTION
This PR builds on #60, but takes the language for the Noncompete in a new direction.

## Economics

Relying on the economics concept of substitution created a lot of confusion. I'm particularly concerned that it took the license away from plain language. Instead of making it possible to apply the license in most cases without professional help, appealing to economic authority introduced the need for economic expertise, on top of legal expertise. For those who can't run out and hire economic consultants, which is most of us, invoking their jargon invites lay confusion about their field, in addition to any lay confusion about the legal concepts.

Writing on economic substitutes that I've reviewed, from economists and courts, tends to split the definition of substitute goods in two.  There's a formal definition: positive cross-elasticity of demand. But the definition I think we actually want is the more intuitive idea of consumers picking or replacing one offering and not another. The fact that there _is_ a formal economic definition of substitution lent a certain sense of specificity and rigor.  It made the language _feel_ precise, to those accustomed to thinking of economics as precise.  But we're _actually_ relying on the intuitive definition riding sidecar with formal theory.  The intuitive definition can only be stated very generally, which is fertile ground for all kinds of arguments.

## New Approach

This PR stands for the idea that we should accept that we're really after the intuitive idea of substitutes, write that intuitive definition into the license in plain terms, without appealing to economic authority, and do what we can from there to make it possible for non-lawyer-non-economists to apply on their own.

One option would be to simply drop "economic" from the front of "economic substitutes". That would avoid appealing to authority, but wouldn't do much for clarity. It would produce lots of arguments about the meaning of the single word "substitutes", which isn't much to go on. Substitutes to who or how many?  How easy is it to substitute?

This PR instead mixes in a few new ingredients, to help structure the question a bit more, without specializing the license to one kind of software, or one kind of competitive offering.

### Functionality Pass-Through

The idea of a product or service passing through the functionality of the software comes most directly from my work on the [API Copyleft License](https://github.com/kemitchell/api-copyleft-license), particularly its [copyleft exception for applications](https://github.com/kemitchell/api-copyleft-license/blob/76f94641b67cc9b4926e270489f932c9a0694332/license.md#applications). The basic insight there was that software is really about functionality, and competition is really about what others---not the licensor, not the licensee---see on offer.

@laughinghan was absolutely pivotal in refining that part of the API Copyleft License, and might find this new effort interesting.

### Value Add

The idea of additional functionality of a different kind comes in part from API Copyleft, but more so from typical value-added-reseller and system-integrator agreements. The fundamental idea there is that end-user customers come to the VARs and ISVs primarily for the value added or integration, not for the generic functionality of the software they're building upon and reselling.

@bradrydzewski has been a welcome bug in my ear about some of these issues, and I'm sure will want a look at this PR.  @heathermeeker has brought more traditional VAR language up as an alternative.

### Kind of Software

If there's been one specific point of repeated feedback, it's that we should make explicit that licensees can't offer the licensed software as a service.  I've personally been reluctant to take that and run with it, because I feared the result would be a niche license tailored especially for database and other cloud-native service vendors, stamped with Polyform's imprimatur, rather than a truly general purpose license that could see adoption by a broad enough licensor base to develop real name recognition and other network effects.

I've responded to that here by adding a clarification making clear that simply delivering or packaging the software in a different way doesn't earn the licensee a free pass. But I've also taken pains to make clear that _any_ such change to the type of the software has the same problem. Not just software-to-service.

Drafting-wise, adding that kind of examples list to a general rule always creates some risk, even when it's left open-ended.  Courts may read it to restrict the general rule, using the items that got included as hints about what the more general terms meant.  The specific examples given may also go out of date.  Software as a service wasn't new when we started calling it "software as a service".  But we'll be surprised by another, parallel development in software delivery in the next few decades, I'm sure. The wheel is ever turning.

I'd like to call @tieguy out for thanks here. He and I have been cooking up a kind of "test suite" for public software license analysis that proved the perfect tool to hand for this. We really ought to get that published.

## Open Questions

1.  Can folks improve the language?  This PR isn't my first formulation, but it's the result of my first push since #60.  It needs other eyes, and likely some polish.

2.  Is using _both_ functionality pass-through _and_ different functionality redundant or complementary?  I tend to see those limitations as drawing the circle closer from two sides, but other might see them as redundant.

3.  Are we really trying to back our way into an exception for applications?  If so, should we state that explicitly, as does API Copyleft?

    There _is_ a structural difference between API Copyleft and Polyform-Noncompete.  Under API Copyleft, the rule is sharing back (copyleft), and the exception is applications.  Under Polyform-Noncompete, the rule is that you can't use the software, and the exception is that you can do so for a permitted purpose.  But any purpose is a permitted purpose, except providing goods or services that compete with the software.  Reminds me of [Wikipedia: Everything which is not forbidden is allowed](https://en.wikipedia.org/wiki/Everything_which_is_not_forbidden_is_allowed).

---

Thanks so much to everyone for thought and attention.  This license was feeling a bit stuck a week ago.  I'm feeling much more optimistic now.