### PR TITLE
Revamp licensor-licensee noncompete

### DIFF
--- a/Polyform-Collaborative.md
+++ b/Polyform-Collaborative.md
@@ -1,0 +1,77 @@
+# Polyform Collaborative License Development Draft
+
+<https://github.com/polyformproject/polyform-licenses/>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## Noncompete
+
+It is not a permitted purpose to provide any offering that competes with the software or any other offering the licensor provides using the software.  However, if you are using the software to provide an offering that does not compete, and the licensor begins providing a competing offering using the software, you may continue using versions of the software available under these terms at that time to provide your offering, but not any later versions made available under these terms.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/Polyform-Collaborative.md
+++ b/Polyform-Collaborative.md
@@ -44,7 +44,7 @@ Use by any charitable organization, educational institution, public research org
 
 You may have "fair use" rights for the software under the law. These terms do not limit them.
 
-## Noncompete
+## Collaboration
 
 It is not a permitted purpose to provide any offering that competes with the software or any other offering the licensor provides using the software.  However, if you are using the software to provide an offering that does not compete, and the licensor begins providing a competing offering using the software, you may continue using versions of the software available under these terms at that time to provide your offering, but not any later versions made available under these terms.
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -38,7 +38,7 @@ Any purpose is a permitted purpose, except for providing any good or service tha
 
 ## Competing Uses
 
-Goods and services compete even when they provide their functionality through different kinds of interfaces, or for different platforms.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages, or for different computer architectures.  If you market a good or service as a practical substitute for the software, another product, or a service, it competes under these terms.
+Goods and services compete even when they provide their functionality through different kinds of interfaces or for different platforms, and even if provided free of charge.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages, or for different computer architectures.  If you market a good or service as a practical substitute for the software, another product, or a service, it competes under these terms.
 
 ## Prior Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -34,7 +34,7 @@ You may have "fair use" rights for the software under the law. These terms do no
 
 ## Noncompete
 
-Any purpose is a permitted purpose, except for providing any good or service that competes with the software or any good or service the licensor provides using the software.
+Any purpose is a permitted purpose, except for providing any good or service that competes with the software or any other good or service the licensor provides using the software.
 
 ## Competing Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -42,7 +42,7 @@ Goods and services compete even when they provide their functionality through di
 
 ## Prior Uses
 
-If you are using the software to provide a good or service that does not compete, and the licensor either releases a new version of the software or begins providing a good or service using the software that brings your good or service into competition, you may continue using versions of the software available under these terms at that time to provide your offering, but not any later versions made available under these terms.
+If you are using the software to provide a good or service that does not compete, and the licensor either releases a new version of the software or begins providing a good or service using the software that brings your good or service into competition, you may continue using versions of the software available under these terms at that time to provide your competing good or service, but not any later versions made available under these terms.
 
 ## No Other Rights
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -42,7 +42,7 @@ Goods and services compete even when they provide their functionality through di
 
 ## Prior Uses
 
-If you are using the software to provide a good or service that does not compete, and the licensor either releases a new version of the software or begins providing another good or service using the software that brings your good or service into competition, you may continue using versions of the software available under these terms at that time to provide your competing good or service, but not any later versions made available under these terms.
+If you are using the software to provide a good or service that does not compete, and the licensor either releases a new version of the software or begins providing another good or service using the software that brings your good or service into competition, you may continue using versions of the software available under these terms at that time to provide your competing good or service, but not any later versions.
 
 ## No Other Rights
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -42,7 +42,7 @@ Goods and services compete even when they provide their functionality through di
 
 ## Prior Uses
 
-If you are using the software to provide a good or service that does not compete, and the licensor either releases a new version of the software or begins providing a good or service using the software that brings your good or service into competition, you may continue using versions of the software available under these terms at that time to provide your competing good or service, but not any later versions made available under these terms.
+If you are using the software to provide a good or service that does not compete, and the licensor either releases a new version of the software or begins providing another good or service using the software that brings your good or service into competition, you may continue using versions of the software available under these terms at that time to provide your competing good or service, but not any later versions made available under these terms.
 
 ## No Other Rights
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -38,7 +38,7 @@ Any purpose is a permitted purpose, except for providing any good or service tha
 
 ## Competing Uses
 
-Goods and services compete even when they provide their functionality through different kinds of interfaces or for different platforms.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages, or for different computer architectures.  Goods and services compete even when provided free of charge.  If you market a good or service as a practical substitute for the software, another product, or a service, it competes under these terms.
+Goods and services compete even when they provide their functionality through different kinds of interfaces or for different platforms.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages, or for different computer architectures.  Moreover, goods and services compete even when provided free of charge.  Finally, if you market a good or service as a practical substitute for the software, another product, or a service, it competes under these terms.
 
 ## Prior Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -38,7 +38,7 @@ Any purpose is a permitted purpose, except for providing any good or service tha
 
 ## Competing Uses
 
-Goods and services compete even when they provide their functionality through different kinds of interfaces or for different platforms, and even if provided free of charge.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages, or for different computer architectures.  If you market a good or service as a practical substitute for the software, another product, or a service, it competes under these terms.
+Goods and services compete even when they provide their functionality through different kinds of interfaces or for different platforms.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages, or for different computer architectures.  Goods and services compete even when provided free of charge.  If you market a good or service as a practical substitute for the software, another product, or a service, it competes under these terms.
 
 ## Prior Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -42,7 +42,7 @@ Goods and services compete even when they provide their functionality through di
 
 ## Prior Uses
 
-If you are using the software to provide a good or service that does not compete, and the licensor either releases a new version of the software or begins providing another good or service using the software that brings your good or service into competition, you may continue using versions of the software available under these terms beforehand to provide your competing good or service, but not any later versions.
+If you are using the software to provide a good or service that does not compete and the licensor brings your good or service into competition by providing a new version of the software or another good or service using the software, you may continue using versions of the software available under these terms beforehand to provide your competing good or service, but not any later versions.
 
 ## No Other Rights
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -38,7 +38,7 @@ Any purpose is a permitted purpose, except for providing any good or service tha
 
 ## Competing Uses
 
-Goods and services compete even when they provide their functionality through different kinds of interfaces or for different platforms.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages, or for different computer architectures.  Moreover, goods and services compete even when provided free of charge.  Finally, if you market a good or service as a practical substitute for the software, another product, or a service, it competes under these terms.
+Goods and services compete even when they provide their functionality through different kinds of interfaces or for different platforms.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages, or for different computer architectures.  Moreover, goods and services compete even when provided free of charge.  Finally, if you market a good or service as a practical substitute for the software, another product, or a service, it definitely competes under these terms.
 
 ## Prior Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -42,7 +42,7 @@ Goods and services compete even when they provide their functionality through di
 
 ## Prior Uses
 
-If you are using the software to provide a good or service that does not compete, and the licensor either releases a new version of the software or begins providing another good or service using the software that brings your good or service into competition, you may continue using versions of the software available under these terms at that time to provide your competing good or service, but not any later versions.
+If you are using the software to provide a good or service that does not compete, and the licensor either releases a new version of the software or begins providing another good or service using the software that brings your good or service into competition, you may continue using versions of the software available under these terms beforehand to provide your competing good or service, but not any later versions.
 
 ## No Other Rights
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -42,7 +42,7 @@ Goods and services compete even when they provide their functionality through di
 
 ## Prior Uses
 
-If you are using the software to provide a good or service that does not compete and the licensor brings your good or service into competition by providing a new version of the software or another good or service using the software, you may continue using versions of the software available under these terms beforehand to provide your competing good or service, but not any later versions.
+If you are using the software to provide a good or service that does not compete, but the licensor brings your good or service into competition by providing a new version of the software or another good or service using the software, you may continue using versions of the software available under these terms beforehand to provide your competing good or service, but not any later versions.
 
 ## No Other Rights
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -28,25 +28,21 @@ The licensor grants you an additional copyright license to make changes and new 
 
 The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
 
-## Noncommercial Purposes
-
-Any noncommercial purpose is a permitted purpose.
-
-## Personal Uses
-
-Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
-
-## Noncommercial Organizations
-
-Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
-
 ## Fair Use
 
 You may have "fair use" rights for the software under the law. These terms do not limit them.
 
 ## Noncompete
 
-It is not a permitted purpose to provide any offering that competes with the software or any other offering the licensor provides using the software.  However, if you are using the software to provide an offering that does not compete, and the licensor begins providing a competing offering using the software, you may continue using versions of the software available under these terms at that time to provide your offering, but not any later versions made available under these terms.
+Any purpose is a permitted purpose, except for providing any good or service that competes with the software or any good or service the licensor provides using the software.
+
+## Competing Uses
+
+Goods and services compete even when they take different forms---application and service, library and plugin, framework and development tool, interpreter and operating system, and so on---or target different programming languages or computing platforms.  If you market a good or service as a practical substitute for the software, another product, or a service, it competes under these terms.
+
+## Prior Uses
+
+If you are using the software to provide a good or service that does not compete, and the licensor either releases a new version of the software or begins providing a good or service using the software that brings your good or service into competition, you may continue using versions of the software available under these terms at that time to provide your offering, but not any later versions made available under these terms.
 
 ## No Other Rights
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -38,7 +38,7 @@ Any purpose is a permitted purpose, except for providing any good or service tha
 
 ## Competing Uses
 
-Goods and services compete even when they take different forms---application and service, library and plugin, framework and development tool, interpreter and operating system, and so on---or target different programming languages or computing platforms.  If you market a good or service as a practical substitute for the software, another product, or a service, it competes under these terms.
+Goods and services compete even when they provide their functionality through different kinds of interfaces, or for different platforms.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages, or for different computer architectures.  If you market a good or service as a practical substitute for the software, another product, or a service, it competes under these terms.
 
 ## Prior Uses
 


### PR DESCRIPTION
This PR applies some of the improvements we've made in #63 and other work focused on defining noncompetition as between products and services back to language defining noncompetition as between licensors and licensees.

cc @￼￼bradrydzewski for badca3c99799e6a45857ceceb4612cb0afba55c0, taking off from https://github.com/polyformproject/polyform-licenses/pull/63#issuecomment-520930615