### PR TITLE
add 'other' after 'or any' in licensor-licensee noncompete

### DIFF
--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -34,7 +34,7 @@ You may have "fair use" rights for the software under the law. These terms do no
 
 ## Noncompete
 
-Any purpose is a permitted purpose, except for providing any good or service that competes with the software or any good or service the licensor provides using the software.
+Any purpose is a permitted purpose, except for providing any good or service that competes with the software or any other good or service the licensor provides using the software.
 
 ## Competing Uses
 


### PR DESCRIPTION
make it slightly easier to see that what the licensor provides is the object of prohibited competition rather than the software being the object of prohibited competition https://github.com/polyformproject/polyform-licenses/pull/64#discussion_r314555873