### PR TITLE
Noncompete: Lines of Business and M&A

### DIFF
--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -44,6 +44,12 @@ Goods and services compete even when they provide their functionality through di
 
 If you are using the software to provide a good or service that does not compete, but the licensor brings your good or service into competition by providing a new version of the software or another good or service using the software, you may continue using versions of the software available under these terms beforehand to provide your competing good or service, but not any later versions.
 
+## Discontinued Uses
+
+You may begin using the software to compete with a good or service that the licensor stops providing, unless the licensor documents that line of business with a plain-text line beginning with `Licensor Line of Business:` provided with the software.  For example:
+
+> Licensor Line of Business: YoyodyneCMS Content Management System (http://example.com/cms)
+
 ## No Other Rights
 
 These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -34,7 +34,7 @@ You may have "fair use" rights for the software under the law. These terms do no
 
 ## Noncompete
 
-Any purpose is a permitted purpose, except for providing any good or service that competes with the software or any other good or service the licensor has provided using the software.
+Any purpose is a permitted purpose, except for providing any good or service that competes with the software or any other good or service the licensor provides using the software.
 
 ## Competing Uses
 

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -50,6 +50,10 @@ You may begin using the software to compete with a good or service that the lice
 
 > Licensor Line of Business: YoyodyneCMS Content Management System (http://example.com/cms)
 
+## Business Transactions
+
+If the licensor sells a line of business using the software to provide a good or service to another company, the buyer can enforce [Noncompete](#noncompete) against competing uses.
+
 ## No Other Rights
 
 These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.

--- a/Polyform-Noncompete.md
+++ b/Polyform-Noncompete.md
@@ -34,7 +34,7 @@ You may have "fair use" rights for the software under the law. These terms do no
 
 ## Noncompete
 
-Any purpose is a permitted purpose, except for providing any good or service that competes with the software or any other good or service the licensor provides using the software.
+Any purpose is a permitted purpose, except for providing any good or service that competes with the software or any other good or service the licensor has provided using the software.
 
 ## Competing Uses
 


### PR DESCRIPTION
Addressing two points of concern from @heathermeeker about the licensor-licensee-based noncompete form:

1. What if a company winds down a line of business for a time?  They should be able to continue enforcing the noncompete.

2. What if a company sells a line of business using the software?  The buyer should be able to enforce the noncompete.

The wind-down scenario is close to a mirror image of the prior-use problem. Fundamentally, how the licensor uses the software can change over time, and without any further license rules, there's no guarantee licensees will have up-to-date information on what they can and cannot compete with.

I've addressed this problem with a notice mechanism: Licensors can include lines about how they are using the software, much as they can include copyright lines, to preserve their rights to enforce the noncompete if the lines of business goes dormant for a time.