### PR TITLE
Licensor noncompete feedback

### DIFF
--- a/Polyform-Free-Trial.md
+++ b/Polyform-Free-Trial.md
@@ -44,15 +44,15 @@ If you violate any of these terms, or do anything with the software not covered 
 
 ## Definitions
 
-The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+The **licensor** is the individual or organization offering these terms, and the **software** is the software the licensor makes available under these terms.
 
-**You** refers to the individual or entity agreeing to these terms.
+**You** refers to the individual or organization agreeing to these terms.
 
 **Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
 
 **Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
 
-**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Control** means ownership of substantially all the assets of an organization, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 

--- a/Polyform-Free-Trial.md
+++ b/Polyform-Free-Trial.md
@@ -48,7 +48,11 @@ The **licensor** is the individual or entity offering these terms, and the **sof
 
 **You** refers to the individual or entity agreeing to these terms.
 
-**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
+
+**Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
+
+**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 

--- a/Polyform-Internal-Use.md
+++ b/Polyform-Internal-Use.md
@@ -44,15 +44,15 @@ The first time you are notified in writing that you have violated any of these t
 
 ## Definitions
 
-The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+The **licensor** is the individual or organization offering these terms, and the **software** is the software the licensor makes available under these terms.
 
-**You** refers to the individual or entity agreeing to these terms.
+**You** refers to the individual or organization agreeing to these terms.
 
 **Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
 
 **Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
 
-**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Control** means ownership of substantially all the assets of an organization, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 
 **Your licenses** are all the licenses granted to you for the software under these terms.

--- a/Polyform-Internal-Use.md
+++ b/Polyform-Internal-Use.md
@@ -48,7 +48,12 @@ The **licensor** is the individual or entity offering these terms, and the **sof
 
 **You** refers to the individual or entity agreeing to these terms.
 
-**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
+
+**Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
+
+**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 

--- a/Polyform-Licensor-Noncompete.md
+++ b/Polyform-Licensor-Noncompete.md
@@ -42,7 +42,7 @@ If you are using the software to provide a good or service that does not compete
 
 ## Discontinued Offerings
 
-You may begin using the software to compete with a product or service that the licensor has stopped providing, unless the licensor includes a plain-text line beginning with `Licensor Line of Business:` mentioning that line of business with the software.  For example:
+You may begin using the software to compete with a product or service that the licensor has stopped providing, unless the licensor includes a plain-text line beginning with `Licensor Line of Business:` with the software that mentions that line of business.  For example:
 
 > Licensor Line of Business: YoyodyneCMS Content Management System (http://example.com/cms)
 

--- a/Polyform-Licensor-Noncompete.md
+++ b/Polyform-Licensor-Noncompete.md
@@ -78,7 +78,11 @@ A **product** can be a good or service, or a combination of them.
 
 **You** refers to the individual or entity agreeing to these terms.
 
-**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
+
+**Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
+
+**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 

--- a/Polyform-Licensor-Noncompete.md
+++ b/Polyform-Licensor-Noncompete.md
@@ -48,7 +48,7 @@ You may begin using the software to compete with a product or service that the l
 
 ## Sales of Business
 
-If the licensor sells a line of business developing the software or using the software to provide a product, the buyer can also enforce [Noncompete](#noncompete).
+If the licensor sells a line of business developing the software or using the software to provide a product, the buyer can also enforce [Noncompete](#noncompete) for that product.
 
 ## Fair Use
 

--- a/Polyform-Licensor-Noncompete.md
+++ b/Polyform-Licensor-Noncompete.md
@@ -30,7 +30,7 @@ The licensor grants you a patent license for the software that covers patent cla
 
 ## Noncompete
 
-Any purpose is a permitted purpose, except for providing any product that competes with the software or any product the licensor provides using the software.
+Any purpose is a permitted purpose, except for providing any product that competes with the software or any product the licensor or any of its affiliates provides using the software.
 
 ## Competition
 
@@ -38,17 +38,17 @@ Goods and services compete even when they provide functionality through differen
 
 ## New Offerings
 
-If you are using the software to provide a product that does not compete, but the licensor brings your product into competition by providing a new version of the software or another product using the software, you may continue using versions of the software available under these terms beforehand to provide your competing product, but not any later versions.
+If you are using the software to provide a product that does not compete, but the licensor or any of its affiliates brings your product into competition by providing a new version of the software or another product using the software, you may continue using versions of the software available under these terms beforehand to provide your competing product, but not any later versions.
 
 ## Discontinued Offerings
 
-You may begin using the software to compete with a product or service that the licensor has stopped providing, unless the licensor includes a plain-text line beginning with `Licensor Line of Business:` with the software that mentions that line of business.  For example:
+You may begin using the software to compete with a product or service that the licensor or any of its affiliates has stopped providing, unless the licensor includes a plain-text line beginning with `Licensor Line of Business:` with the software that mentions that line of business.  For example:
 
 > Licensor Line of Business: YoyodyneCMS Content Management System (http://example.com/cms)
 
 ## Sales of Business
 
-If the licensor sells a line of business developing the software or using the software to provide a product, the buyer can also enforce [Noncompete](#noncompete) for that product.
+If the licensor or any of its affiliates sells a line of business developing the software or using the software to provide a product, the buyer can also enforce [Noncompete](#noncompete) for that product.
 
 ## Fair Use
 

--- a/Polyform-Licensor-Noncompete.md
+++ b/Polyform-Licensor-Noncompete.md
@@ -72,17 +72,17 @@ The first time you are notified in writing that you have violated any of these t
 
 ## Definitions
 
-The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+The **licensor** is the individual or organization offering these terms, and the **software** is the software the licensor makes available under these terms.
 
 A **product** can be a good or service, or a combination of them.
 
-**You** refers to the individual or entity agreeing to these terms.
+**You** refers to the individual or organization agreeing to these terms.
 
 **Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
 
 **Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
 
-**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Control** means ownership of substantially all the assets of an organization, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 

--- a/Polyform-Licensor-Noncompete.md
+++ b/Polyform-Licensor-Noncompete.md
@@ -30,15 +30,15 @@ The licensor grants you a patent license for the software that covers patent cla
 
 ## Noncompete
 
-Any purpose is a permitted purpose, except for providing any good or service that competes with the software or any good or service the licensor provides using the software.
+Any purpose is a permitted purpose, except for providing any product that competes with the software or any product the licensor provides using the software.
 
 ## Competition
 
-Goods and services compete even when they provide functionality through different kinds of interfaces or for different technical platforms.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages or for different computer architectures.  Goods and services compete even when provided free of charge.  If you market a good or service as a practical substitute for the software, another product, or a service, it definitely competes.
+Goods and services compete even when they provide functionality through different kinds of interfaces or for different technical platforms.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages or for different computer architectures.  Goods and services compete even when provided free of charge.  If you market a product as a practical substitute for the software or another product, it definitely competes.
 
 ## New Offerings
 
-If you are using the software to provide a good or service that does not compete, but the licensor brings your good or service into competition by providing a new version of the software or another good or service using the software, you may continue using versions of the software available under these terms beforehand to provide your competing good or service, but not any later versions.
+If you are using the software to provide a product that does not compete, but the licensor brings your product into competition by providing a new version of the software or another product using the software, you may continue using versions of the software available under these terms beforehand to provide your competing product, but not any later versions.
 
 ## Discontinued Offerings
 
@@ -73,6 +73,8 @@ The first time you are notified in writing that you have violated any of these t
 ## Definitions
 
 The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+A **product** can be a good or service, or a combination of them.
 
 **You** refers to the individual or entity agreeing to these terms.
 

--- a/Polyform-Licensor-Noncompete.md
+++ b/Polyform-Licensor-Noncompete.md
@@ -36,11 +36,11 @@ Any purpose is a permitted purpose, except for providing any product that compet
 
 Goods and services compete even when they provide functionality through different kinds of interfaces or for different technical platforms.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages or for different computer architectures.  Goods and services compete even when provided free of charge.  If you market a product as a practical substitute for the software or another product, it definitely competes.
 
-## New Offerings
+## New Products
 
 If you are using the software to provide a product that does not compete, but the licensor or any of its affiliates brings your product into competition by providing a new version of the software or another product using the software, you may continue using versions of the software available under these terms beforehand to provide your competing product, but not any later versions.
 
-## Discontinued Offerings
+## Discontinued Products
 
 You may begin using the software to compete with a product or service that the licensor or any of its affiliates has stopped providing, unless the licensor includes a plain-text line beginning with `Licensor Line of Business:` with the software that mentions that line of business.  For example:
 

--- a/Polyform-Noncommercial.md
+++ b/Polyform-Noncommercial.md
@@ -66,7 +66,11 @@ The **licensor** is the individual or entity offering these terms, and the **sof
 
 **You** refers to the individual or entity agreeing to these terms.
 
-**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
+
+**Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
+
+**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 

--- a/Polyform-Noncommercial.md
+++ b/Polyform-Noncommercial.md
@@ -62,15 +62,15 @@ The first time you are notified in writing that you have violated any of these t
 
 ## Definitions
 
-The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+The **licensor** is the individual or organization offering these terms, and the **software** is the software the licensor makes available under these terms.
 
-**You** refers to the individual or entity agreeing to these terms.
+**You** refers to the individual or organization agreeing to these terms.
 
 **Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
 
 **Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
 
-**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Control** means ownership of substantially all the assets of an organization, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 

--- a/Polyform-Project-Nonmcompete.md
+++ b/Polyform-Project-Nonmcompete.md
@@ -58,17 +58,17 @@ The first time you are notified in writing that you have violated any of these t
 
 ## Definitions
 
-The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+The **licensor** is the individual or organization offering these terms, and the **software** is the software the licensor makes available under these terms.
 
 A **product** can be a good or service, or a combination of them.
 
-**You** refers to the individual or entity agreeing to these terms.
+**You** refers to the individual or organization agreeing to these terms.
 
 **Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
 
 **Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
 
-**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Control** means ownership of substantially all the assets of an organization, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 

--- a/Polyform-Project-Nonmcompete.md
+++ b/Polyform-Project-Nonmcompete.md
@@ -64,7 +64,11 @@ A **product** can be a good or service, or a combination of them.
 
 **You** refers to the individual or entity agreeing to these terms.
 
-**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
+
+**Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
+
+**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 

--- a/Polyform-Small-Business.md
+++ b/Polyform-Small-Business.md
@@ -58,7 +58,11 @@ The **licensor** is the individual or entity offering these terms, and the **sof
 
 **You** refers to the individual or entity agreeing to these terms.
 
-**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
+
+**Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
+
+**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 

--- a/Polyform-Small-Business.md
+++ b/Polyform-Small-Business.md
@@ -54,15 +54,15 @@ The first time you are notified in writing that you have violated any of these t
 
 ## Definitions
 
-The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+The **licensor** is the individual or organization offering these terms, and the **software** is the software the licensor makes available under these terms.
 
-**You** refers to the individual or entity agreeing to these terms.
+**You** refers to the individual or organization agreeing to these terms.
 
 **Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
 
 **Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
 
-**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Control** means ownership of substantially all the assets of an organization, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 

--- a/Polyform-Strict.md
+++ b/Polyform-Strict.md
@@ -52,7 +52,11 @@ The **licensor** is the individual or entity offering these terms, and the **sof
 
 **You** refers to the individual or entity agreeing to these terms.
 
-**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
+
+**Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
+
+**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 

--- a/Polyform-Strict.md
+++ b/Polyform-Strict.md
@@ -48,15 +48,15 @@ The first time you are notified in writing that you have violated any of these t
 
 ## Definitions
 
-The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+The **licensor** is the individual or organization offering these terms, and the **software** is the software the licensor makes available under these terms.
 
-**You** refers to the individual or entity agreeing to these terms.
+**You** refers to the individual or organization agreeing to these terms.
 
 **Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
 
 **Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
 
-**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+**Control** means ownership of substantially all the assets of an organization, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
 
 **Your licenses** are all the licenses granted to you for the software under these terms.
 


### PR DESCRIPTION
Responding to feedback on Polyform-Licensor-Noncompete.

- [x] Use the "product" definition from Polyform-Project-Noncompete.
- [x] Limit an acquirer's right to enforce the noncompete to competition with the product they acquired.
- [x] Cover licensor affiliates' products.

I also made some changes to the Definitions sections of all the licenses to add a definition of "affiliates".

Still to do:

- [ ] Address feedback about limiting New ~~Offerings~~Products and Discontinued ~~Offerings~~Products to products that were made "generally available" at the relevant times.